### PR TITLE
Fix bug for undefined 'completion' argument

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,7 @@ name    = Complete-Getopt-Long
 [Prereqs / TestRequires]
 Complete::Bash=0.27
 Test::More=0.98
+Test::Deep=0.107
 
 [Prereqs]
 perl=5.010001

--- a/lib/Complete/Getopt/Long.pm
+++ b/lib/Complete/Getopt/Long.pm
@@ -557,7 +557,7 @@ sub complete_cli_arg {
         );
         $log->tracef('[comp][compgl] invoking \'completion\' routine '.
                          'to complete argument');
-        my $compres = $comp->(%compargs);
+        my $compres = $comp->(%compargs) if $comp;
         if (!defined $compres) {
             $compres = _default_completion(%compargs);
             $log->tracef('[comp][compgl] adding result from default '.


### PR DESCRIPTION
-Perl errors with 'Can't use an undefined value as a subroutine reference'
-This error causes GetOptions in Getopt::Long::Complete to fail
-Tests missed this by explicitly using `completion //= sub{[]}`, presumably to avoid dealing with defaults in the expected completions
-Updated tests to deal with the defaults in expected results

I'm not sure if my updates to the tests are completely appropriate, since they depend on Complete::Getopt::Long::_default_completion, but I do believe my tiny fix to the module addresses this bug.
