### PR TITLE
set required Getopt::Long::Util to what is actually avaialble on CPAN

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -25,7 +25,7 @@ Complete::Env=0
 Complete::File=0.440
 Complete::Util=0.608
 Exporter=5.57
-Getopt::Long::Util=0.896
+Getopt::Long::Util=0.895
 Log::ger=0.038
 String::Wildcard::Bash=0.044
 


### PR DESCRIPTION
This fixes [rt#144312](https://rt.cpan.org/Public/Bug/Display.html?id=144312) and #2 